### PR TITLE
Update to 1.1.6 and add standard R maintainers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license: FOSS
 
 Feedstock license: BSD 3-Clause
 
-Summary: Allows for fast, correct, consistent, portable, as well as convenient character string/text processing in every locale and any native encoding. Owing to the use of the ICU library, the package provides R users with platform-independent functions known to Java, Perl, Python, PHP, and Ruby programmers. Among available features there are: pattern searching (e.g., with ICU Java-like regular expressions or the Unicode Collation Algorithm), random string generation, case mapping, string transliteration, concatenation, Unicode normalization, date-time formatting and parsing, etc.
+Summary: Allows for fast, correct, consistent, portable, as well as convenient character string/text processing in every locale and any native encoding. Owing to the use of the ICU library, the package provides R users with platform-independent functions known to Java, Perl, Python, PHP, and Ruby programmers. Available features include: pattern searching (e.g., with ICU Java-like regular expressions or the Unicode Collation Algorithm), random string generation, case mapping, string transliteration, concatenation, Unicode normalization, date-time formatting and parsing, etc.
 
 
 
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,24 +37,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,22 @@
-{% set version = "1.1.5" %}
+{% set version = '1.1.6' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
 
 package:
   name: r-stringi
-  version: {{ version }}
+  version: {{ version|replace("-", "_") }}
 
 source:
   fn: stringi_{{ version }}.tar.gz
   url:
-    - http://cran.r-project.org/src/contrib/stringi_{{ version }}.tar.gz
-    - http://cran.r-project.org/src/contrib/Archive/stringi/stringi_{{ version }}.tar.gz
-  sha256: 651e85fc4ec6cf71ad8a4347f2bd4b00a490cf9eec20921a83bf5222740402f2 
+    - https://cran.r-project.org/src/contrib/stringi_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/stringi/stringi_{{ version }}.tar.gz
+  sha256: 9590360b96627b18d7bed273deedabda4283dbae7d41c0a0ba78a58e6aa95188
 
 build:
   number: 0
-  skip: True  # [win32]
-  script: R CMD INSTALL --build .
+  skip: true  # [win32]
   rpaths:
     - lib/R/lib/
     - lib/
@@ -22,16 +24,18 @@ build:
 requirements:
   build:
     - r-base
-    - posix            # [win]
-    - m2w64-toolchain  # [win]
-    - gcc              # [not win]
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
   run:
     - r-base
+    - libgcc  # [not win]
 
 test:
   commands:
-    - R -e "library('stringi')"  # [not win]
-    - R -e \"library('stringi')\"  # [win]
+    - $R -e "library('stringi')"  # [not win]
+    - "\"%R%\" -e \"library('stringi')\""  # [win]
 
 about:
   home: http://www.gagolewski.com/software/stringi
@@ -40,12 +44,17 @@ about:
   summary: 'Allows for fast, correct, consistent, portable, as well as convenient character string/text
     processing in every locale and any native encoding. Owing to the use of the ICU
     library, the package provides R users with platform-independent functions known
-    to Java, Perl, Python, PHP, and Ruby programmers. Among available features there
-    are: pattern searching (e.g., with ICU Java-like regular expressions or the Unicode
-    Collation Algorithm), random string generation, case mapping, string transliteration,
-    concatenation, Unicode normalization, date-time formatting and parsing, etc.'
+    to Java, Perl, Python, PHP, and Ruby programmers. Available features include: pattern
+    searching (e.g., with ICU Java-like regular expressions or the Unicode Collation Algorithm), random
+    string generation, case mapping, string transliteration, concatenation, Unicode normalization,
+    date-time formatting and parsing, etc.'
+  license_family: OTHER
 
 extra:
   recipe-maintainers:
     - ocefpaf
-    - mariusvniekerk  
+    - mariusvniekerk
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak


### PR DESCRIPTION
This PR updates r-stringi to 1.1.6 (prerequisite for r-stringr 1.3.0) and tries to bring the recipe closer to many others within conda-forge, including adding the "standard" maintainers.