### PR TITLE
Bump build number to fix ICU pinning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  number: 3
+  number: 4
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
closes https://github.com/conda-forge/r-stringi-feedstock/issues/18